### PR TITLE
Explicitly set passive to false when binding mouse wheel event listeners

### DIFF
--- a/src/uniwheel.js
+++ b/src/uniwheel.js
@@ -7,7 +7,6 @@ module.exports = (function(){
   //Full details: https://developer.mozilla.org/en-US/docs/Web/Reference/Events/wheel
 
   var prefix = "", _addEventListener, _removeEventListener, support, fns = [];
-  var passiveOption = {passive: true};
 
   // detect event model
   if ( window.addEventListener ) {
@@ -95,7 +94,7 @@ module.exports = (function(){
       cb = createCallback(elem, callback);
     }
 
-    elem[_addEventListener](prefix + eventName, cb, isPassiveListener ? passiveOption : false);
+    elem[_addEventListener](prefix + eventName, cb, { passive: isPassiveListener ? true : false }, false);
   }
 
   function _removeWheelListener(elem, eventName, callback, isPassiveListener ) {
@@ -108,7 +107,7 @@ module.exports = (function(){
       cb = getCallback(elem);
     }
 
-    elem[_removeEventListener](prefix + eventName, cb, isPassiveListener ? passiveOption : false);
+    elem[_removeEventListener](prefix + eventName, cb, { passive: isPassiveListener ? true : false }, false);
 
     removeCallback(elem);
   }
@@ -137,3 +136,4 @@ module.exports = (function(){
   };
 
 })();
+


### PR DESCRIPTION
Mousewheel event listeners registered on document level targets in Chrome will be treated as passive unless explicitly set to false. Calling preventDefault inside passive listeners is ignored and logs a console error. I've changed the mousewheel add listener calls to now explicitly set passive to false when needed.